### PR TITLE
feat: add maintenance release support with hotfix/betafix branches

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -8,12 +8,14 @@ const isReleaseBranch = ['master'].includes(branch);
 const branches = [
   "master",
   {
-    "name": "beta",
-    "prerelease": true,
+    name: "{hotfix,hot-fix}{-,/}*",
+    prerelease: "hotfix",
+    channel: "hotfix"
   },
   {
-    "name": "devel",
-    "prerelease": true,
+    name: "{betafix,beta-fix}{-,/}*",
+    prerelease: "betafix",
+    channel: "betafix"
   },
 ];
 


### PR DESCRIPTION
## Summary
- Removed beta and devel branch configurations
- Added hotfix pattern: `{hotfix,hot-fix}{-,/}*` with npm tag `hotfix`
- Added betafix pattern: `{betafix,beta-fix}{-,/}*` with npm tag `betafix`

## Changes
This enables publishing prerelease versions for maintenance hotfixes:
- Supports both dash and slash separators (e.g., `hotfix/2025-01-14` or `hotfix-critical-bug`)
- Hotfix branches publish with `@hotfix` npm tag
- Betafix branches publish with `@betafix` npm tag

## Example Workflow
1. Create branch from version tag: `git checkout -b hotfix/2025-01-14 v1.1.0`
2. Make fix and commit: `fix: critical security issue`
3. Push → publishes `1.1.0-hotfix.1` with `@hotfix` tag
4. Install: `npm install package@1.1.0-hotfix.1`

## Test Plan
- [ ] Verify branch pattern matching with `npx semantic-release --dry-run`
- [ ] Test hotfix release flow
- [ ] Test betafix release flow